### PR TITLE
[Feature] #32 Reachability 이용하여 네트워크 연결여부 확인하고 토스트 띄워주기

### DIFF
--- a/MogakStudy.xcodeproj/project.pbxproj
+++ b/MogakStudy.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A203D24729225F8A00B11636 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A203D24629225F8A00B11636 /* BaseVC.swift */; };
 		A203D24929225F9800B11636 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A203D24829225F9800B11636 /* BaseView.swift */; };
+		A203D24C292261ED00B11636 /* NetworkReachableManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A203D24B292261ED00B11636 /* NetworkReachableManager.swift */; };
 		A23E7A8A291A333D005B746F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A23E7A89291A333D005B746F /* GoogleService-Info.plist */; };
 		A23E7A8D291A3BC6005B746F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A23E7A8C291A3BC6005B746F /* SnapKit */; };
 		A23E7A90291A3BD6005B746F /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A23E7A8F291A3BD6005B746F /* Then */; };
@@ -44,6 +45,7 @@
 /* Begin PBXFileReference section */
 		A203D24629225F8A00B11636 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		A203D24829225F9800B11636 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		A203D24B292261ED00B11636 /* NetworkReachableManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkReachableManager.swift; sourceTree = "<group>"; };
 		A23E7A89291A333D005B746F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A23E7AA5291A669D005B746F /* MogakStudy.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MogakStudy.entitlements; sourceTree = "<group>"; };
 		A2499A9C291DD48900A81D07 /* FBAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBAuthManager.swift; sourceTree = "<group>"; };
@@ -102,9 +104,18 @@
 			path = Base;
 			sourceTree = "<group>";
 		};
+		A203D24A292261CB00B11636 /* NetworkReachable */ = {
+			isa = PBXGroup;
+			children = (
+				A203D24B292261ED00B11636 /* NetworkReachableManager.swift */,
+			);
+			path = NetworkReachable;
+			sourceTree = "<group>";
+		};
 		A2499A9A291DD46200A81D07 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				A203D24A292261CB00B11636 /* NetworkReachable */,
 				A2499A9B291DD47500A81D07 /* Auth */,
 				A29329F6291FF11B0044816B /* Network */,
 			);
@@ -372,6 +383,7 @@
 				A254D4532918DE1300AC5006 /* SceneDelegate.swift in Sources */,
 				A203D24929225F9800B11636 /* BaseView.swift in Sources */,
 				A2932A1A292216880044816B /* UIView+UIStackView+Extension.swift in Sources */,
+				A203D24C292261ED00B11636 /* NetworkReachableManager.swift in Sources */,
 				A2932A22292256A00044816B /* OnboardingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MogakStudy/Data/NetworkReachable/NetworkReachableManager.swift
+++ b/MogakStudy/Data/NetworkReachable/NetworkReachableManager.swift
@@ -1,0 +1,77 @@
+//
+//  NetworkReachableManager.swift
+//  MogakStudy
+//
+//  Created by Doy Kim on 2022/11/14.
+//
+
+import Foundation
+import Reachability
+
+class NetworkReachableManager: NSObject {
+    var reachability: Reachability!
+    
+    static let shared = NetworkReachableManager()
+    
+    
+    override init() {
+        super.init()
+        // Initialise reachability
+        do {
+            reachability = try Reachability()
+        } catch {
+           
+           print(error)
+        }
+        
+        // Register an observer for the network status
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(networkStatusChanged(_:)),
+            name: .reachabilityChanged,
+            object: reachability
+        )
+        do {
+            // Start the network status notifier
+            try reachability.startNotifier()
+        } catch {
+            print("Unable to start notifier")
+        }
+    }
+    @objc func networkStatusChanged(_ notification: Notification) {
+        // Do something globally here!
+    }
+    static func stopNotifier() -> Void {
+        do {
+            // Stop the network status notifier
+            try (NetworkReachableManager.shared.reachability).startNotifier()
+        } catch {
+            print("Error stopping notifier")
+        }
+    }
+
+    // Network is reachable
+    func isReachable(completed: @escaping (NetworkReachableManager) -> Void) {
+        if (NetworkReachableManager.shared.reachability).connection != .unavailable {
+            completed(NetworkReachableManager.shared)
+        }
+    }
+    // Network is unreachable
+    func isUnreachable(completed: @escaping (NetworkReachableManager) -> Void) {
+        if (NetworkReachableManager.shared.reachability).connection == .unavailable {
+            completed(NetworkReachableManager.shared)
+        }
+    }
+    // Network is reachable via WWAN/Cellular
+    func isReachableViaWWAN(completed: @escaping (NetworkReachableManager) -> Void) {
+        if (NetworkReachableManager.shared.reachability).connection == .cellular {
+            completed(NetworkReachableManager.shared)
+        }
+    }
+    // Network is reachable via WiFi
+    func isReachableViaWiFi(completed: @escaping (NetworkReachableManager) -> Void) {
+        if (NetworkReachableManager.shared.reachability).connection == .wifi {
+            completed(NetworkReachableManager.shared)
+        }
+    }
+}

--- a/MogakStudy/Presentation/Concierge/ConciergeVC.swift
+++ b/MogakStudy/Presentation/Concierge/ConciergeVC.swift
@@ -8,9 +8,12 @@
 import UIKit
 import SnapKit
 import Then
+import Toast
 
 class ConciergeVC: UIViewController {
     // MARK: - Properties
+    let networkReachableManager = NetworkReachableManager.shared
+    
     let splashImage = UIImageView().then {
         $0.contentMode = .scaleAspectFit
         $0.image = UIImage(named: "splash_logo")
@@ -26,6 +29,7 @@ class ConciergeVC: UIViewController {
         print(#function)
         configure()
         setConstraints()
+        checkNetworkAvailability()
     }
     
     // MARK: - Helpers
@@ -46,6 +50,13 @@ class ConciergeVC: UIViewController {
             make.width.equalToSuperview().multipliedBy(0.8)
             make.height.equalTo(splashText.snp.width).multipliedBy(0.34)
             make.top.equalTo(splashImage.snp.bottom).offset(28)
+        }
+    }
+    
+    // MARK: - Actions
+    func checkNetworkAvailability() {
+        networkReachableManager.isUnreachable { [weak self] _ in
+            self?.view.makeToast("네트워크 연결을 다시 확인해주세요", duration: 1.8, position: .center)
         }
     }
 }


### PR DESCRIPTION
### ✨ Motivation & Background
<!-- PR을 작성하게 된 이유-->
Reachability 이용하여 네트워크 연결여부 확인하고 토스트 띄워주기
-> 로그인 및 회원가입이 모두 네트워크가 연결되어야 가능한 활동이기 때문에 

### 🔑 **Key Changes**
<!-- 작업 내용 -->
- Reachability 를 이용해 네트워크 상태를 확인하는 클래스  선언
- ConciergeView에서 싱글톤으로 가져온 인스턴스를 이용해, 네트워크가 연결이 안 되어있을 경우 Toast로 띄워줌 

### 🧪 Testing
<!-- 테스트 방법-->
맥북 와이파이를 끄고 iPhone 11 15.5 시뮬레이터로 테스트 

### 🏞 Screenshots
<!-- 스크린샷 또는 동영상, GIF -->
<!--  <img src=".png" width="350">   -->

|Feature|Screenshot|
|:--:|:--:|
| | |


### 📝 Review Note 
<!-- 개선 사항 또는  아이디어  -->
분기되는 화면을 붙일 때 이 부분을 고려하여 연결 
스타벅스 앱처럼 확인버튼을 눌렀을 때 네트워크 연결이 되었다면 화면을 연결해줄 수 있으면 좋을 것 같다. 

### 📣 Related Issue
<!-- 관련 이슈 -->
- close #32


### 📬 Reference
<!-- 참고한 내용 및 출처 -->
