### PR TITLE
[Feature] #36 DateFormatter를 이용해 필요한 문자열로 바꿔주는 메서드 정의

### DIFF
--- a/MogakStudy.xcodeproj/project.pbxproj
+++ b/MogakStudy.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A20A45742922BC01003CC900 /* OnboardingCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A45732922BC01003CC900 /* OnboardingCVC.swift */; };
 		A20A45762922BEB9003CC900 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A45752922BEB9003CC900 /* NSMutableAttributedString+Extension.swift */; };
 		A20A45782922CC30003CC900 /* UICVC+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A45772922CC30003CC900 /* UICVC+Extension.swift */; };
+		A20A457B2922E63E003CC900 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A457A2922E63E003CC900 /* Date+Extension.swift */; };
 		A23E7A8A291A333D005B746F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A23E7A89291A333D005B746F /* GoogleService-Info.plist */; };
 		A23E7A8D291A3BC6005B746F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A23E7A8C291A3BC6005B746F /* SnapKit */; };
 		A23E7A90291A3BD6005B746F /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A23E7A8F291A3BD6005B746F /* Then */; };
@@ -73,6 +74,7 @@
 		A20A45732922BC01003CC900 /* OnboardingCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCVC.swift; sourceTree = "<group>"; };
 		A20A45752922BEB9003CC900 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
 		A20A45772922CC30003CC900 /* UICVC+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICVC+Extension.swift"; sourceTree = "<group>"; };
+		A20A457A2922E63E003CC900 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		A23E7A89291A333D005B746F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A23E7AA5291A669D005B746F /* MogakStudy.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MogakStudy.entitlements; sourceTree = "<group>"; };
 		A2499A9C291DD48900A81D07 /* FBAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBAuthManager.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				A2932A19292216880044816B /* UIView+UIStackView+Extension.swift */,
 				A20A45772922CC30003CC900 /* UICVC+Extension.swift */,
 				A20A45752922BEB9003CC900 /* NSMutableAttributedString+Extension.swift */,
+				A20A457A2922E63E003CC900 /* Date+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -448,6 +451,7 @@
 				A254D46E29196BE800AC5006 /* setColor.swift in Sources */,
 				A2932A24292256B70044816B /* OnboardingVC.swift in Sources */,
 				A29329F8291FF1280044816B /* Router.swift in Sources */,
+				A20A457B2922E63E003CC900 /* Date+Extension.swift in Sources */,
 				A20A45722922BB4C003CC900 /* OnboardingModel.swift in Sources */,
 				A254D48B2919D6A500AC5006 /* I18NStrings.swift in Sources */,
 				A2499A9D291DD48900A81D07 /* FBAuthManager.swift in Sources */,

--- a/MogakStudy/Global/Extension/Date+Extension.swift
+++ b/MogakStudy/Global/Extension/Date+Extension.swift
@@ -1,0 +1,33 @@
+//
+//  Date+Extension.swift
+//  MogakStudy
+//
+//  Created by Doy Kim on 2022/11/15.
+//
+
+import Foundation
+
+extension Date {
+    /// 날짜를 분리된 년,월,일로 보내줍니다.
+    func dateToSeperateYMD() -> [String] {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMMdd"
+        
+        let date = dateFormatter.string(from: self)
+        
+        let year = String(date[0...3])
+        let month = String(date[4...5])
+        let day = String(date[6...7])
+        
+        return [year, month, day]
+    }
+    
+    /// 회원가입을 서버로 보낼 때 유효한 형태로 생년월일을 바꿔줍니다.
+    func changeToValidBirthday() -> String {
+        let dateFormater = DateFormatter()
+        dateFormater.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        let validDate = dateFormater.string(from: self)
+        
+        return validDate
+    }
+}

--- a/MogakStudy/Global/Extension/String+Extension.swift
+++ b/MogakStudy/Global/Extension/String+Extension.swift
@@ -29,4 +29,39 @@ extension String {
         let test = NSPredicate(format: "SELF MATCHES %@", regex)
         return test.evaluate(with: self)
     }
+    
+    /// String 첨자
+    subscript(value: Int) -> Character {
+        self[index(at: value)]
+    }
+    
+    subscript(value: NSRange) -> Substring {
+        self[value.lowerBound..<value.upperBound]
+    }
+    
+    subscript(value: CountableClosedRange<Int>) -> Substring {
+        self[index(at: value.lowerBound)...index(at: value.upperBound)]
+    }
+    
+    subscript(value: CountableRange<Int>) -> Substring {
+        self[index(at: value.lowerBound)..<index(at: value.upperBound)]
+    }
+    
+    subscript(value: PartialRangeUpTo<Int>) -> Substring {
+        self[..<index(at: value.upperBound)]
+    }
+    
+    subscript(value: PartialRangeThrough<Int>) -> Substring {
+        self[...index(at: value.upperBound)]
+    }
+    
+    subscript(value: PartialRangeFrom<Int>) -> Substring {
+        self[index(at: value.lowerBound)...]
+    }
+    
+    
+    func index(at offset: Int) -> String.Index {
+        index(startIndex, offsetBy: offset)
+    }
+    
 }


### PR DESCRIPTION
### ✨ Motivation & Background
<!-- PR을 작성하게 된 이유-->
DateFormatter를 이용해 필요한 문자열로 바꿔주는 메서드 정의

### 🔑 **Key Changes**
<!-- 작업 내용 -->

- 문자열 첨자를 관리하는 메서드 익스텐션으로 추가
- 날짜를 년,월,일로 바꿔주는 메서드 추가 
- 날짜를 회원가입에 유효한  형태로 바꿔주는 메서드추가 

### 🧪 Testing
<!-- 테스트 방법-->


### 🏞 Screenshots
<!-- 스크린샷 또는 동영상, GIF -->
<!--  <img src=".png" width="350">   -->

|Feature|Screenshot|
|:--:|:--:|
| | |


### 📝 Review Note 
<!-- 개선 사항 또는  아이디어  -->


### 📣 Related Issue
<!-- 관련 이슈 -->
- close #36 


### 📬 Reference
<!-- 참고한 내용 및 출처 -->
- DateFormatter 형식 
https://formestory.tistory.com/6

- 문자열 첨자 
https://stackoverflow.com/questions/45562662/how-can-i-use-string-substring-in-swift-4-substringto-is-deprecated-pleas

- 날짜 포맷 중간에 T가 들어갈 때는 '' 작은 따옴표로 묶어주기 
https://stackoverflow.com/questions/41907419/ios-swift-3-convert-yyyy-mm-ddthhmmssz-format-string-to-date-object