### PR TITLE
[Feature] #35 아이디토큰과 FCM 토큰을 UserDefaults로 저장하는 로그인매니저 클래스 선언

### DIFF
--- a/MogakStudy.xcodeproj/project.pbxproj
+++ b/MogakStudy.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A20A45762922BEB9003CC900 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A45752922BEB9003CC900 /* NSMutableAttributedString+Extension.swift */; };
 		A20A45782922CC30003CC900 /* UICVC+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A45772922CC30003CC900 /* UICVC+Extension.swift */; };
 		A20A457B2922E63E003CC900 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A457A2922E63E003CC900 /* Date+Extension.swift */; };
+		A20A45852922EF4D003CC900 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A45842922EF4D003CC900 /* LoginManager.swift */; };
 		A23E7A8A291A333D005B746F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A23E7A89291A333D005B746F /* GoogleService-Info.plist */; };
 		A23E7A8D291A3BC6005B746F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A23E7A8C291A3BC6005B746F /* SnapKit */; };
 		A23E7A90291A3BD6005B746F /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A23E7A8F291A3BD6005B746F /* Then */; };
@@ -75,6 +76,7 @@
 		A20A45752922BEB9003CC900 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
 		A20A45772922CC30003CC900 /* UICVC+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICVC+Extension.swift"; sourceTree = "<group>"; };
 		A20A457A2922E63E003CC900 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		A20A45842922EF4D003CC900 /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		A23E7A89291A333D005B746F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A23E7AA5291A669D005B746F /* MogakStudy.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MogakStudy.entitlements; sourceTree = "<group>"; };
 		A2499A9C291DD48900A81D07 /* FBAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBAuthManager.swift; sourceTree = "<group>"; };
@@ -158,9 +160,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		A20A45802922EF33003CC900 /* UserDefaults */ = {
+			isa = PBXGroup;
+			children = (
+				A20A45842922EF4D003CC900 /* LoginManager.swift */,
+			);
+			path = UserDefaults;
+			sourceTree = "<group>";
+		};
 		A2499A9A291DD46200A81D07 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				A20A45802922EF33003CC900 /* UserDefaults */,
 				A203D24A292261CB00B11636 /* NetworkReachable */,
 				A2499A9B291DD47500A81D07 /* Auth */,
 				A29329F6291FF11B0044816B /* Network */,
@@ -448,6 +459,7 @@
 			files = (
 				A2932A27292257B30044816B /* ConciergeVC.swift in Sources */,
 				A20A45742922BC01003CC900 /* OnboardingCVC.swift in Sources */,
+				A20A45852922EF4D003CC900 /* LoginManager.swift in Sources */,
 				A254D46E29196BE800AC5006 /* setColor.swift in Sources */,
 				A2932A24292256B70044816B /* OnboardingVC.swift in Sources */,
 				A29329F8291FF1280044816B /* Router.swift in Sources */,

--- a/MogakStudy/App/AppDelegate.swift
+++ b/MogakStudy/App/AppDelegate.swift
@@ -42,6 +42,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             } else if let token = token {
                 print("FCM registration token: \(token)")
                 //self.fcmRegTokenMessage.text  = "Remote FCM registration token: \(token)"
+                // FCM 토큰 저장
+                LoginManager.shared.FCMtoken = token
             }
         }
         

--- a/MogakStudy/Data/UserDefaults/LoginManager.swift
+++ b/MogakStudy/Data/UserDefaults/LoginManager.swift
@@ -1,0 +1,30 @@
+//
+//  LoginManager.swift
+//  MogakStudy
+//
+//  Created by Doy Kim on 2022/11/15.
+//
+
+import Foundation
+
+class LoginManager {
+
+    static let shared = LoginManager()
+    
+    var idToken: String? {
+        get {
+            UserDefaults.standard.string(forKey: "idToken")
+            
+        } set {
+            UserDefaults.standard.setValue(newValue, forKey: "idToken")
+        }
+    }
+   
+    var FCMtoken: String? {
+        get {
+            UserDefaults.standard.string(forKey: "FCMtoken")
+        } set {
+            UserDefaults.standard.setValue(newValue, forKey: "FCMtoken")
+        }
+    }
+}

--- a/MogakStudy/Presentation/Concierge/ConciergeVC.swift
+++ b/MogakStudy/Presentation/Concierge/ConciergeVC.swift
@@ -61,7 +61,7 @@ class ConciergeVC: UIViewController {
         if networkReachableManager.reachability.connection == .unavailable {
            view.makeToast("네트워크 연결을 다시 확인해주세요", duration: 1.8, position: .center)
         } else {
-            if let idtoken = UserDefaults.standard.string(forKey: "idtoken") {
+            if let idtoken = LoginManager.shared.idToken {
                 // 로그인
                 print(idtoken)
             } else {


### PR DESCRIPTION
### ✨ Motivation & Background
<!-- PR을 작성하게 된 이유-->
아이디토큰과 FCM 토큰을 UserDefaults로 저장하는 로그인매니저 클래스 선언

### 🔑 **Key Changes**
<!-- 작업 내용 -->
- 아이디토큰과 FCM 토큰을 UserDefaults로 저장하는 로그인매니저 클래스 선언
- AppDelegate에서 로그인매니저 이용하여 FCM 토큰 저장
- ConciergeVC에서 idToken 저장여부를 확인하여 분기하는 곳에 로그인매니저 싱글톤 사용 

### 🧪 Testing
<!-- 테스트 방법-->


### 🏞 Screenshots
<!-- 스크린샷 또는 동영상, GIF -->
<!--  <img src=".png" width="350">   -->

|Feature|Screenshot|
|:--:|:--:|
| | |


### 📝 Review Note 
<!-- 개선 사항 또는  아이디어  -->


### 📣 Related Issue
<!-- 관련 이슈 -->
- close #35


### 📬 Reference
<!-- 참고한 내용 및 출처 -->
